### PR TITLE
fix: fixing usage-guide example sdk install command

### DIFF
--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -39,7 +39,7 @@ cd a2a-pubsub
 Install the Agntcy Application SDK and Langgraph:
 
 ```bash
-uv install agntcy-app-sdk
+uv add agntcy-app-sdk
 ```
 
 Next we will create a simple weather agent that responds to weather queries. Create a file named `weather_agent.py` and implement the A2A agent and add a message bridge to a SLIM transport:


### PR DESCRIPTION
# Description

Fixing usage-guide example sdk install command. Replaces `uv install agntcy-app-sdk` with `uv add agntcy-app-sdk`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
