### PR TITLE
Add Trace Instrumentation for NATS Transport

### DIFF
--- a/tests/unit/test_transport_nats.py
+++ b/tests/unit/test_transport_nats.py
@@ -1,0 +1,41 @@
+from agntcy_app_sdk.transports.nats.transport import NatsTransport
+
+
+def test_extract_message_payload_ids_realistic():
+    t = NatsTransport(endpoint="nats://localhost:4222")
+
+    # Case 1: Message with no id or messageId (path/method only)
+    payload1 = {"path": ".well-known/agent.json", "method": "GET"}
+    id_, message_id = t._extract_message_payload_ids(payload1)
+    assert id_ is None
+    assert message_id is None
+
+    # Case 2: Message with both id and nested messageId
+    payload2 = {
+        "id": "c8f0f828-978a-4503-a613-17822b05a87c",
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "kind": "message",
+                "messageId": "89186480-3f05-4098-ab06-2610a66afa93",
+                "parts": [
+                    {
+                        "kind": "text",
+                        "text": "Please provide the total coffee yield inventory across all farms."
+                    }
+                ],
+                "role": "user"
+            }
+        }
+    }
+    id_, message_id = t._extract_message_payload_ids(payload2)
+    assert id_ == "c8f0f828-978a-4503-a613-17822b05a87c"
+    assert message_id == "89186480-3f05-4098-ab06-2610a66afa93"
+
+    # Case 3: Same as above but as JSON string
+    import json
+    payload2_str = json.dumps(payload2)
+    id_, message_id = t._extract_message_payload_ids(payload2_str)
+    assert id_ == "c8f0f828-978a-4503-a613-17822b05a87c"
+    assert message_id == "89186480-3f05-4098-ab06-2610a66afa93"


### PR DESCRIPTION
# Description

This PR is to add trace instrumentation for NATS so client apps will be able to see the NATS-related operations through their observability stack. 

## Trace example - all farm yield inventory
Example prompt:`"Show me the total inventory of all farms."`:

<img width="1734" height="969" alt="Screenshot 2025-08-27 at 11 03 24" src="https://github.com/user-attachments/assets/829a9752-e47a-48c4-8c10-b959b2f66fda" />

## Trace example - farm yield inventory
Example prompt:`"How much coffee does the Colombia farm have?"`:

<img width="1360" height="905" alt="farms_yield" src="https://github.com/user-attachments/assets/257ab442-0404-4fdb-8153-9dd2e6abf15a" />

## Trace example - order creation
Example prompt:`"I need 50 lb of coffee beans from Colombia for 0.50 cents per lb"`:

<img width="1519" height="1192" alt="order_creation" src="https://github.com/user-attachments/assets/cbd69dea-68ea-4e4c-bd2e-8b6863421455" />

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
