### PR TITLE
chore: only allow PyPI triggered via CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,7 @@ name: sdk-release-python
 on:
   push:
     tags:
-      - "v*"          # Broad glob; strict semver enforced in validation step
-  workflow_dispatch: # Allow manual triggering of the workflow
+      - "v*"          # Only trigger on tag push
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -75,9 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-sdk-wheel
-    if: |
-      always() &&
-      (needs.build-sdk-wheel.result == 'skipped' || needs.build-sdk-wheel.result == 'success')
+    if: needs.build-sdk-wheel.result == 'success'
     environment: pypi
     permissions:
       id-token: write


### PR DESCRIPTION
# Description

Ensure build-sdk-wheel passes before we publish to PyPI

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
