### PR TITLE
fix: address callback is None issue

### DIFF
--- a/src/agntcy_app_sdk/bridge.py
+++ b/src/agntcy_app_sdk/bridge.py
@@ -33,7 +33,10 @@ class MessageBridge:
         self.handler = self.protocol_handler.handle_message
 
         # Set callback BEFORE transport setup
-        self.transport.set_callback(self._process_message)
+        if inspect.iscoroutinefunction(self.transport.set_callback):
+            await self.transport.set_callback(self._process_message)
+        else:
+            self.transport.set_callback(self._process_message)
         # Set up the transport layer (this starts the listener task)
         await self.transport.setup()
 


### PR DESCRIPTION
# Description
If there is any chance that multiple tasks or threads might access or modify self._callback (i.e. _set_callback method) concurrently, adding a lock is a good practice to avoid race conditions.

This change may fix the issue:
```
2025-09-29 18:47:35,002 [ERROR] agntcy_app_sdk.transports.slim.transport: Error in callback function: 'NoneType' object is not callable
```

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
