### PR TITLE
feat: removing session listener from setup() to avoid multiple listen…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ name: sdk-release-python
 on:
   push:
     tags:
-      - "v*"          # Only trigger on tag push
+      - "v*" # Only trigger on tag push
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ Publishing to PyPI is automated via GitHub Actions. To release a new version:
 
 **Note:** Tags must always be created from the `main` branch and must match the version in `pyproject.toml`.
 
-
 # Contributing
 
 Contributions are welcome! Please see the [contribution guide](CONTRIBUTING.md) for details on how to contribute to the Agntcy Application SDK.

--- a/src/agntcy_app_sdk/bridge.py
+++ b/src/agntcy_app_sdk/bridge.py
@@ -32,10 +32,11 @@ class MessageBridge:
         # set the message handler to the protocol handler's handle_message method
         self.handler = self.protocol_handler.handle_message
 
-        # Set callback BEFORE transport setup
-        self.transport.set_callback(self._process_message)
         # Set up the transport layer (this starts the listener task)
         await self.transport.setup()
+
+        # Set callback AFTER transport setup
+        self.transport.set_callback(self._process_message)
 
         await self.transport.subscribe(self.topic)
 

--- a/src/agntcy_app_sdk/protocols/a2a/protocol.py
+++ b/src/agntcy_app_sdk/protocols/a2a/protocol.py
@@ -381,7 +381,6 @@ class A2AProtocol(BaseAgentProtocol):
             "body": bytearray(),
         }
 
-
         async def send(message: Dict[str, Any]) -> None:
             message_type = message["type"]
 
@@ -419,7 +418,7 @@ class A2AProtocol(BaseAgentProtocol):
                 "status": "error",
             }
             error_payload = json.dumps(error_response).encode("utf-8")
-            
+
             return Message(
                 type="A2AResponse",
                 payload=error_payload,

--- a/src/agntcy_app_sdk/transports/slim/session_manager.py
+++ b/src/agntcy_app_sdk/transports/slim/session_manager.py
@@ -140,7 +140,9 @@ class SessionManager:
 
             logger.info(f"waiting before closing session: {session.id}")
             # todo: proper way to wait for all messages to be processed
-            await asyncio.sleep(random.uniform(5, 10)) # add sleep before closing to allow for any in-flight messages to be processed
+            await asyncio.sleep(
+                random.uniform(5, 10)
+            )  # add sleep before closing to allow for any in-flight messages to be processed
             logger.info(f"deleting session: {session.id}")
             await self._slim.delete_session(session.id)
             logger.debug(f"Closed session: {session.id}")


### PR DESCRIPTION
# Description

PR fixes issues with concurrent group sessions errors caused by multiple slim session receivers. Moved the slim transport session listening task out of transport.setup() and into transport.set_callback() to ensure only transports in server mode will run the session listening loop.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
