### PR TITLE
fix: store created request_reply_session session to local cache

### DIFF
--- a/src/agntcy_app_sdk/transport/slim/session_manager.py
+++ b/src/agntcy_app_sdk/transport/slim/session_manager.py
@@ -67,6 +67,8 @@ class SessionManager:
                     mls_enabled=mls_enabled,
                 )
             )
+            # store session to local cache so it can be reused
+            self._sessions[session.id] = session
             return session.id, session
 
     async def group_broadcast_session(


### PR DESCRIPTION
# Description

Currently, it seems the created session is not stored in local cache so the created session may never be re-used.

This fix is to store the created session using its session id as key to local cache.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
