### PR TITLE
Replace threading.Lock with asyncio.Lock for improved async concurrency

### DIFF
--- a/src/agntcy_app_sdk/transports/slim/session_manager.py
+++ b/src/agntcy_app_sdk/transports/slim/session_manager.py
@@ -14,7 +14,6 @@ from slim_bindings import (
     PySessionDirection,
 )
 from agntcy_app_sdk.transports.transport import Message
-from threading import Lock
 
 configure_logging()
 logger = get_logger(__name__)
@@ -24,7 +23,7 @@ class SessionManager:
     def __init__(self):
         self._sessions: Dict[str, PySessionInfo] = {}
         self._slim = None
-        self._lock = Lock()
+        self._lock = asyncio.Lock()
 
     def set_slim(self, slim: slim_bindings.Slim):
         """
@@ -58,7 +57,7 @@ class SessionManager:
                 )
                 continue
 
-        with self._lock:
+        async with self._lock:
             session = await self._slim.create_session(
                 PySessionConfiguration.FireAndForget(
                     max_retries=max_retries,
@@ -88,7 +87,7 @@ class SessionManager:
             [str(invitee) for invitee in invitees]
         )
         # use the same lock for session creation and lookup
-        with self._lock:
+        async with self._lock:
             if session_key in self._sessions:
                 logger.info(f"Reusing existing group broadcast session: {session_key}")
                 return session_key, self._sessions[session_key]
@@ -160,16 +159,16 @@ class SessionManager:
             logger.info(f"Closed session: {session.id}")
 
             # remove from local store
-            self._local_cache_cleanup(session.id)
+            await self._local_cache_cleanup(session.id)
         except Exception as e:
             logger.warning(f"Error closing SLIM session {session.id}: {e}")
             return
 
-    def _local_cache_cleanup(self, session_id: int):
+    async def _local_cache_cleanup(self, session_id: int):
         """
         Perform local cleanup of a session without attempting to close it on the SLIM client.
         """
-        with self._lock:
+        async with self._lock:
             session_key = None
             for key, sess in self._sessions.items():
                 if sess.id == session_id:


### PR DESCRIPTION
# Description

This PR addresses a critical concurrency issue within the `SessionManager` by replacing the synchronous `threading.Lock` with the asynchronous `asyncio.Lock`.


The previous implementation used `threading.Lock` to protect shared state in methods like `request_reply_session()` and `group_broadcast_session()`. However, `threading.Lock` is a blocking primitive designed for multi-threaded environments. Reference: https://docs.python.org/3/library/threading.html#lock-objects

In an asyncio application, when an await call occurs within a `with self._lock`, the threading.Lock remains held by the underlying OS thread. This effectively blocks the entire event loop, preventing other asyncio tasks from running concurrently even when the current task is merely waiting for an I/O operation. This behavior severely limits the benefits of asynchronous programming, leading to:

- Reduced concurrency.
- Potential performance bottlenecks.
- Unintended serialization of asynchronous operations.

Hence the proposal to switch to `asyncio.Lock`

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
