### PR TITLE
Remove macos-13 runner as it has been deprecated

### DIFF
--- a/.github/workflows/reusable-python-build-wheel.yaml
+++ b/.github/workflows/reusable-python-build-wheel.yaml
@@ -25,9 +25,6 @@ jobs:
           - runner: windows-latest
             os: windows
             target: x64
-          - runner: macos-13 # We use macos-13 as it is a x86_64 runner
-            os: macos
-            target: x86_64
           - runner: macos-15
             os: macos
             target: aarch64


### PR DESCRIPTION
# Description

macos-13 images have been deprecated, see https://github.com/actions/runner-images/issues/13046

Resulting failing GHA job during tag release: https://github.com/agntcy/app-sdk/actions/runs/19084389352

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
