### PR TITLE
fix: Address FastMCP Client Improperly Disconnects Upstream A2A Server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agntcy-app-sdk"
-version = "0.4.3"
+version = "0.4.4-dev.0"
 description = "Agntcy Application SDK for Python"
 authors = [{ name = "Cody Hartsook", email = "codyhartsook@gmail.com" }]
 requires-python = ">=3.12,<4.0"

--- a/src/agntcy_app_sdk/semantic/fast_mcp/client.py
+++ b/src/agntcy_app_sdk/semantic/fast_mcp/client.py
@@ -23,11 +23,10 @@ class MCPClient:
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
-        if self.transport:
-            try:
-                await self.transport.close()
-            except Exception as e:
-                logger.error(f"transport close failed: {e}")
+        # Passive cleanup only. Transport and sessions should not be closed here.
+        # Transport will close during server/bridge shutdown, and sessions will close
+        # at the transport level after the point-to-point communication (FastMCP's only mode) completes.
+        pass
 
     def _build_message(
         self,


### PR DESCRIPTION
### PR Description

#### Summary
This PR addresses an issue where the FastMCP client's `transport.close()` call causes the upstream A2A server to disconnect unexpectedly. The issue was observed when running the FastMCP client within an `app-sdk` A2A server.

#### Problem
- The `transport.close()` call improperly disconnects the upstream A2A server, leading to errors in message processing and client mapping removal.
- Logs indicate that the connection was removed prematurely, resulting in errors such as:
```
2025-11-11 18:27:50 [agntcy_app_sdk.transport.slim.transport] [ERROR] [_listen_for_sessions:517] Error receiving session info: error receiving message: failed to receive notification: error in message forwarding: status: Internal, message: "error processing message: ProcessingError(\"error handling publish: error sending message: connection 1 not found\")", details: [], metadata: MetadataMap { headers: {} }
2025-11-12T02:27:55.310323Z ERROR tokio-runtime-worker slim_datapath::message_processing: error processing incoming message conn_index=0 e=error processing message: error handling publish: error sending message: connection 1 not found
2025-11-12T02:27:55.310353Z ERROR tokio-runtime-worker slim_service::app: error: status: Internal, message: "error processing message: ProcessingError(\"error handling publish: error sending message: connection 1 not found\")", details: [], metadata: MetadataMap { headers: {} }
2025-11-11 18:27:55 [agntcy_app_sdk.transport.slim.transport] [ERROR] [_listen_for_sessions:517] Error receiving session info: error receiving message: failed to receive notification: error in message forwarding: status: Internal, message: "error processing message: ProcessingError(\"error handling publish: error sending message: connection 1 not found\")", details: [], metadata: MetadataMap { headers: {} }
2025-11-12T02:28:00.312640Z ERROR tokio-runtime-worker slim_datapath::message_processing: error processing incoming message conn_index=0 e=error processing message: error handling publish: error sending message: connection 1 not found
```

#### Changes
- Updated the FastMCP client exit method to ensure it does not interfere with the upstream A2A server connection.


## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
