### PR TITLE
Lower minimum required Uvicorn version from >=34.0 to >=29.0 to support packages with lower compatibility constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "nats-py>=2.10.0,<3",
     "coloredlogs>=15.0.1,<16",
     "langchain-community>=0.3.24",
-    "uvicorn>=0.34.3",
+    "uvicorn>=0.29.0",
     "mcp[cli]>=1.10.1",
     "httpx>=0.28.1",
     "ioa-observe-sdk==1.0.24",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <4.0"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -29,7 +29,7 @@ wheels = [
 
 [[package]]
 name = "agntcy-app-sdk"
-version = "0.4.2"
+version = "0.4.4.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -70,7 +70,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.10.1" },
     { name = "nats-py", specifier = ">=2.10.0,<3" },
     { name = "slim-bindings", specifier = "==0.6.3" },
-    { name = "uvicorn", specifier = ">=0.34.3" },
+    { name = "uvicorn", specifier = ">=0.29.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

This PR reduces the minimum required version of Uvicorn from >=34.0 to >=29.0 in our project dependencies. Lowering the threshold to >=29.0 maintains compatibility with our application while ensuring that libraries depending on older Uvicorn versions can be integrated without resolver failures. This change is intentionally minimal and only adjusts version constraints

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
