### PR TITLE
feat: Implement decoupled HTTP bind host (A2A) and update documentation

### DIFF
--- a/docs/A2A_USAGE_GUIDE.md
+++ b/docs/A2A_USAGE_GUIDE.md
@@ -480,8 +480,10 @@ if __name__ == "__main__":
   - `.with_factory(factory)` — reuse an existing `AgntcyFactory` (auto-created if omitted)
   - `.skip(transport_type)` — exclude a specific transport (e.g., `.skip("jsonrpc")`)
   - `.override(transport_type, target)` — supply a pre-built transport or config for a specific interface
+  - `.with_http_bind_host(host)` — set the interface `jsonrpc`/`http` servers bind to, decoupled from the advertised card URL host
   - `.dry_run()` — returns a `ServeCardPlan` describing what _would_ be started, without starting anything
 - **`SLIM_SHARED_SECRET`:** Required environment variable for any SLIM-based transport. Set it before calling `start()`.
+- **JSONRPC/HTTP bind host:** `jsonrpc`/`http` interfaces bind all interfaces (`0.0.0.0`) by default, decoupled from the advertised card URL host. This lets you advertise a routable DNS name (e.g. a Kubernetes Service) while still binding correctly inside the pod. Override with `.with_http_bind_host("127.0.0.1")` or the `AGNTCY_A2A_HTTP_BIND_HOST` env var (precedence: setter > env > `0.0.0.0`).
 - **URL formats:** Each interface URL supports two styles:
   - **Topic-only:** `slim://my_topic` — endpoint resolved from `SLIM_ENDPOINT` env var (default: `http://localhost:46357`)
   - **Explicit endpoint:** `slim://host:46357/my_topic` — endpoint extracted from the URL

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -743,6 +743,30 @@ def override(transport_type: str, target: object) -> CardBuilder
 
 ---
 
+##### with_http_bind_host()
+
+Set the network interface that `jsonrpc` / `http` interfaces bind to, decoupled
+from the advertised card URL host.
+
+```python
+def with_http_bind_host(host: str) -> CardBuilder
+```
+
+**Parameters:**
+
+| Parameter | Type  | Required | Description                                       |
+| --------- | ----- | -------- | ------------------------------------------------- |
+| `host`    | `str` | Yes      | Interface to bind (e.g., `"0.0.0.0"`, `"127.0.0.1"`) |
+
+By default the bind host is resolved from the `AGNTCY_A2A_HTTP_BIND_HOST`
+environment variable, falling back to `0.0.0.0` (all interfaces). The advertised
+card URL host (from the `AgentInterface` URL) is used only for the card and
+logging — not for binding. Precedence: setter > env var > `0.0.0.0` default.
+
+**Returns:** `CardBuilder` (for chaining)
+
+---
+
 ##### dry_run()
 
 Return a plan describing what would be started, without actually starting anything.

--- a/src/agntcy_app_sdk/app_sessions.py
+++ b/src/agntcy_app_sdk/app_sessions.py
@@ -110,15 +110,18 @@ class ContainerBuilder:
         handler_class = _resolve_handler_class(self._target)
 
         # A2ASRPCServerHandler takes (config) — no transport or topic
-        from agntcy_app_sdk.semantic.a2a.server.srpc import A2ASRPCServerHandler
+        from agntcy_app_sdk.semantic.a2a.server.experimental_patterns import (
+            A2AExperimentalServerHandler,
+        )
 
         # When the target is an A2AStarletteApplication but no transport was
         # provided, serve it over native HTTP JSONRPC instead of going through
         # the patterns handler (which requires a transport).
-        from agntcy_app_sdk.semantic.a2a.server.jsonrpc import A2AJsonRpcServerHandler
-        from agntcy_app_sdk.semantic.a2a.server.experimental_patterns import (
-            A2AExperimentalServerHandler,
+        from agntcy_app_sdk.semantic.a2a.server.jsonrpc import (
+            A2AJsonRpcServerHandler,
+            resolve_http_bind_host,
         )
+        from agntcy_app_sdk.semantic.a2a.server.srpc import A2ASRPCServerHandler
 
         if handler_class is A2AExperimentalServerHandler and self._transport is None:
             if self._host is None or self._port is None:
@@ -127,11 +130,13 @@ class ContainerBuilder:
                     "(no transport). Use .with_host() and .with_port() on "
                     "the builder."
                 )
+
+            bind_host = resolve_http_bind_host(self._bind_host)
             handler = A2AJsonRpcServerHandler(
                 self._target,
                 host=self._host,
                 port=self._port,
-                bind_host=self._bind_host,
+                bind_host=bind_host,
             )
         elif handler_class is A2ASRPCServerHandler:
             if self._transport is not None or self._topic is not None:

--- a/src/agntcy_app_sdk/app_sessions.py
+++ b/src/agntcy_app_sdk/app_sessions.py
@@ -75,6 +75,7 @@ class ContainerBuilder:
         self._session_id: Optional[str] = None
         self._host: Optional[str] = None
         self._port: Optional[int] = None
+        self._bind_host: Optional[str] = None
 
     def with_transport(self, transport: BaseTransport) -> ContainerBuilder:
         self._transport = transport
@@ -94,6 +95,10 @@ class ContainerBuilder:
 
     def with_host(self, host: str) -> ContainerBuilder:
         self._host = host
+        return self
+
+    def with_bind_host(self, host: str) -> ContainerBuilder:
+        self._bind_host = host
         return self
 
     def with_port(self, port: int) -> ContainerBuilder:
@@ -126,6 +131,7 @@ class ContainerBuilder:
                 self._target,
                 host=self._host,
                 port=self._port,
+                bind_host=self._bind_host,
             )
         elif handler_class is A2ASRPCServerHandler:
             if self._transport is not None or self._topic is not None:

--- a/src/agntcy_app_sdk/semantic/a2a/server/card_bootstrap.py
+++ b/src/agntcy_app_sdk/semantic/a2a/server/card_bootstrap.py
@@ -51,7 +51,11 @@ from urllib.parse import urlparse
 from agntcy_app_sdk.common.logging_config import get_logger
 from agntcy_app_sdk.semantic.a2a.transport_types import (
     CANONICAL_TRANSPORTS as _CANONICAL_TRANSPORTS,
+)
+from agntcy_app_sdk.semantic.a2a.transport_types import (
     InterfaceTransport,
+)
+from agntcy_app_sdk.semantic.a2a.transport_types import (
     normalize_transport as _normalize_transport,
 )
 
@@ -586,20 +590,17 @@ class CardBuilder:
                     )
                     continue
 
-                bind_host = (
-                    self._http_bind_host
-                    or os.environ.get("AGNTCY_A2A_HTTP_BIND_HOST")
-                    or "0.0.0.0"
-                )
                 app_target = override if override is not None else a2a_app
-                (
+                builder = (
                     session.add(app_target)
                     .with_host(str(parsed["host"]))
                     .with_port(int(parsed["port"]))
-                    .with_bind_host(bind_host)
                     .with_session_id(session_id)
-                    .build()
                 )
+
+                if self._http_bind_host is not None:
+                    builder.with_bind_host(self._http_bind_host)
+                builder.build()
 
         if dry_run:
             return plan

--- a/src/agntcy_app_sdk/semantic/a2a/server/card_bootstrap.py
+++ b/src/agntcy_app_sdk/semantic/a2a/server/card_bootstrap.py
@@ -312,6 +312,7 @@ class CardBuilder:
         self._overrides: dict[str, object] = {}  # canonical transport_type -> pre-built
         self._skips: set[str] = set()  # canonical transport_types to skip
         self._shared_secret: str | None = None
+        self._http_bind_host: str | None = None
 
     # -- Fluent setters -----------------------------------------------------
 
@@ -343,6 +344,18 @@ class CardBuilder:
         time if neither is available and a SLIM-based transport is declared.
         """
         self._shared_secret = secret
+        return self
+
+    def with_http_bind_host(self, host: str) -> CardBuilder:
+        """Set the interface JSONRPC/HTTP interfaces bind to.
+
+        This is independent of the advertised card URL host. When not
+        called, the bind host is resolved from the
+        ``AGNTCY_A2A_HTTP_BIND_HOST`` environment variable, falling back to
+        ``0.0.0.0`` (bind all interfaces).  Use ``127.0.0.1`` to restrict
+        binding to loopback.
+        """
+        self._http_bind_host = host
         return self
 
     # -- Terminal operations ------------------------------------------------
@@ -573,11 +586,17 @@ class CardBuilder:
                     )
                     continue
 
+                bind_host = (
+                    self._http_bind_host
+                    or os.environ.get("AGNTCY_A2A_HTTP_BIND_HOST")
+                    or "0.0.0.0"
+                )
                 app_target = override if override is not None else a2a_app
                 (
                     session.add(app_target)
                     .with_host(str(parsed["host"]))
                     .with_port(int(parsed["port"]))
+                    .with_bind_host(bind_host)
                     .with_session_id(session_id)
                     .build()
                 )

--- a/src/agntcy_app_sdk/semantic/a2a/server/jsonrpc.py
+++ b/src/agntcy_app_sdk/semantic/a2a/server/jsonrpc.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Optional
 
 import uvicorn
@@ -14,6 +15,25 @@ from agntcy_app_sdk.common.logging_config import get_logger
 from agntcy_app_sdk.semantic.a2a.server.base import BaseA2AServerHandler
 
 logger = get_logger(__name__)
+
+# Environment variable and default for the JSONRPC/HTTP bind interface.
+_HTTP_BIND_HOST_ENV = "AGNTCY_A2A_HTTP_BIND_HOST"
+_DEFAULT_HTTP_BIND_HOST = "0.0.0.0"
+
+
+def resolve_http_bind_host(explicit: Optional[str] = None) -> str:
+    """Resolve the interface a JSONRPC/HTTP server should bind to.
+
+    This is independent of the advertised card URL host. Precedence:
+
+    1. ``explicit`` value (e.g. from ``ContainerBuilder.with_bind_host()`` /
+       ``CardBuilder.with_http_bind_host()``),
+    2. the ``AGNTCY_A2A_HTTP_BIND_HOST`` environment variable,
+    3. ``0.0.0.0`` (bind all interfaces).
+
+    Use ``127.0.0.1`` to restrict binding to loopback.
+    """
+    return explicit or os.environ.get(_HTTP_BIND_HOST_ENV) or _DEFAULT_HTTP_BIND_HOST
 
 
 class A2AJsonRpcServerHandler(BaseA2AServerHandler):

--- a/src/agntcy_app_sdk/semantic/a2a/server/jsonrpc.py
+++ b/src/agntcy_app_sdk/semantic/a2a/server/jsonrpc.py
@@ -39,11 +39,13 @@ class A2AJsonRpcServerHandler(BaseA2AServerHandler):
         *,
         host: str,
         port: int,
+        bind_host: Optional[str] = None,
     ):
         # BaseA2AServerHandler -> ServerHandler expects (managed_object, ...)
         super().__init__(server, transport=None, topic=None)
         self._server = server
         self._host = host
+        self._bind_host = bind_host or host
         self._port = port
         self._server_task: Optional[asyncio.Task] = None
         self._uvicorn_server: Optional[uvicorn.Server] = None
@@ -75,7 +77,7 @@ class A2AJsonRpcServerHandler(BaseA2AServerHandler):
         app = self._server.build()
         config = uvicorn.Config(
             app=app,
-            host=self._host,
+            host=self._bind_host,
             port=self._port,
             loop="asyncio",
         )
@@ -86,7 +88,10 @@ class A2AJsonRpcServerHandler(BaseA2AServerHandler):
             self._uvicorn_server.serve(),
             name="jsonrpc-server",
         )
-        logger.debug(f"JSONRPC A2A handler started on {self._host}:{self._port}")
+        logger.debug(
+            f"JSONRPC A2A handler bound {self._bind_host}:{self._port} "
+            f"(advertised host={self._host})"
+        )
 
     async def teardown(self) -> None:
         """Stop the Uvicorn server."""

--- a/tests/unit/test_app_session.py
+++ b/tests/unit/test_app_session.py
@@ -42,3 +42,43 @@ async def test_app_session():
     assert app_session.get_app_container("test_session") is None, (
         "App container was not removed properly."
     )
+
+
+@pytest.mark.asyncio
+async def test_container_builder_passes_bind_host():
+    """`.with_bind_host()` is forwarded to the JSONRPC handler, decoupled from host."""
+    factory = AgntcyFactory()
+    app_session = factory.create_app_session(max_sessions=1)
+
+    container = (
+        app_session.add(default_a2a_server)
+        .with_host("example.com")
+        .with_bind_host("0.0.0.0")
+        .with_port(9000)
+        .with_session_id("bind_host_session")
+        .build()
+    )
+
+    handler = container.handler
+    assert handler._host == "example.com"
+    assert handler._bind_host == "0.0.0.0"
+    assert handler._port == 9000
+
+
+@pytest.mark.asyncio
+async def test_container_builder_bind_host_defaults_to_host():
+    """Without `.with_bind_host()`, the handler binds the advertised host."""
+    factory = AgntcyFactory()
+    app_session = factory.create_app_session(max_sessions=1)
+
+    container = (
+        app_session.add(default_a2a_server)
+        .with_host("127.0.0.1")
+        .with_port(9001)
+        .with_session_id("default_bind_session")
+        .build()
+    )
+
+    handler = container.handler
+    assert handler._host == "127.0.0.1"
+    assert handler._bind_host == "127.0.0.1"

--- a/tests/unit/test_app_session.py
+++ b/tests/unit/test_app_session.py
@@ -1,9 +1,13 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+from unittest.mock import patch
+
+import pytest
+
 from agntcy_app_sdk.factory import AgntcyFactory
 from tests.server.a2a_starlette_server import default_a2a_server
-import pytest
 
 pytest_plugins = "pytest_asyncio"
 
@@ -66,19 +70,66 @@ async def test_container_builder_passes_bind_host():
 
 
 @pytest.mark.asyncio
-async def test_container_builder_bind_host_defaults_to_host():
-    """Without `.with_bind_host()`, the handler binds the advertised host."""
+async def test_container_builder_bind_host_defaults_to_all_interfaces():
+    """Without `.with_bind_host()` or env, the handler binds all interfaces."""
     factory = AgntcyFactory()
     app_session = factory.create_app_session(max_sessions=1)
 
-    container = (
-        app_session.add(default_a2a_server)
-        .with_host("127.0.0.1")
-        .with_port(9001)
-        .with_session_id("default_bind_session")
-        .build()
-    )
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AGNTCY_A2A_HTTP_BIND_HOST", None)
+        container = (
+            app_session.add(default_a2a_server)
+            .with_host("127.0.0.1")
+            .with_port(9001)
+            .with_session_id("default_bind_session")
+            .build()
+        )
 
     handler = container.handler
+    # Advertised host is preserved; bind host defaults to 0.0.0.0.
     assert handler._host == "127.0.0.1"
+    assert handler._bind_host == "0.0.0.0"
+
+
+@pytest.mark.asyncio
+async def test_container_builder_bind_host_from_env():
+    """`AGNTCY_A2A_HTTP_BIND_HOST` is used when no explicit bind host is set."""
+    factory = AgntcyFactory()
+    app_session = factory.create_app_session(max_sessions=1)
+
+    with patch.dict(
+        os.environ, {"AGNTCY_A2A_HTTP_BIND_HOST": "127.0.0.1"}, clear=False
+    ):
+        container = (
+            app_session.add(default_a2a_server)
+            .with_host("example.com")
+            .with_port(9002)
+            .with_session_id("env_bind_session")
+            .build()
+        )
+
+    handler = container.handler
+    assert handler._host == "example.com"
     assert handler._bind_host == "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_container_builder_bind_host_setter_beats_env():
+    """`.with_bind_host()` takes precedence over the env var."""
+    factory = AgntcyFactory()
+    app_session = factory.create_app_session(max_sessions=1)
+
+    with patch.dict(
+        os.environ, {"AGNTCY_A2A_HTTP_BIND_HOST": "127.0.0.1"}, clear=False
+    ):
+        container = (
+            app_session.add(default_a2a_server)
+            .with_host("example.com")
+            .with_bind_host("10.0.0.1")
+            .with_port(9003)
+            .with_session_id("precedence_bind_session")
+            .build()
+        )
+
+    handler = container.handler
+    assert handler._bind_host == "10.0.0.1"

--- a/tests/unit/test_card_bootstrap.py
+++ b/tests/unit/test_card_bootstrap.py
@@ -731,16 +731,15 @@ class TestCardBuilderBuildsContainers:
             await builder.start()
 
         session.add.assert_called_once()
-        # Advertised host comes from the card URL; bind host defaults to 0.0.0.0.
         mock_builder.with_host.assert_called_once_with("example.com")
         mock_builder.with_port.assert_called_once_with(9999)
-        mock_builder.with_bind_host.assert_called_once_with("0.0.0.0")
+        mock_builder.with_bind_host.assert_not_called()
         mock_builder.with_session_id.assert_called_once_with("http-0")
         session.start_all_sessions.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_http_bind_host_setter_precedence(self):
-        """`.with_http_bind_host()` takes precedence over env and default."""
+    async def test_http_bind_host_setter_forwarded(self):
+        """`.with_http_bind_host()` is forwarded to the container builder."""
         mock_builder = MagicMock()
         mock_builder.with_host.return_value = mock_builder
         mock_builder.with_port.return_value = mock_builder
@@ -768,36 +767,6 @@ class TestCardBuilderBuildsContainers:
             await builder.start()
 
         mock_builder.with_host.assert_called_once_with("example.com")
-        mock_builder.with_bind_host.assert_called_once_with("127.0.0.1")
-
-    @pytest.mark.asyncio
-    async def test_http_bind_host_env(self):
-        """`AGNTCY_A2A_HTTP_BIND_HOST` is used when no setter is called."""
-        mock_builder = MagicMock()
-        mock_builder.with_host.return_value = mock_builder
-        mock_builder.with_port.return_value = mock_builder
-        mock_builder.with_bind_host.return_value = mock_builder
-        mock_builder.with_session_id.return_value = mock_builder
-        mock_builder.build.return_value = MagicMock()
-
-        session = MagicMock()
-        session.add.return_value = mock_builder
-        session.start_all_sessions = AsyncMock()
-
-        card = _make_card(
-            interfaces=[
-                AgentInterface(transport="jsonrpc", url="http://example.com:9999")
-            ]
-        )
-        handler = MagicMock()
-        builder = CardBuilder(session, card, handler)
-        builder.with_factory(MagicMock())
-
-        with patch.dict(
-            os.environ, {"AGNTCY_A2A_HTTP_BIND_HOST": "127.0.0.1"}, clear=False
-        ):
-            await builder.start()
-
         mock_builder.with_bind_host.assert_called_once_with("127.0.0.1")
 
     @pytest.mark.asyncio

--- a/tests/unit/test_card_bootstrap.py
+++ b/tests/unit/test_card_bootstrap.py
@@ -704,6 +704,7 @@ class TestCardBuilderBuildsContainers:
         mock_builder = MagicMock()
         mock_builder.with_host.return_value = mock_builder
         mock_builder.with_port.return_value = mock_builder
+        mock_builder.with_bind_host.return_value = mock_builder
         mock_builder.with_session_id.return_value = mock_builder
         mock_builder.build.return_value = MagicMock()
 
@@ -717,7 +718,7 @@ class TestCardBuilderBuildsContainers:
             interfaces=[
                 AgentInterface(
                     transport="jsonrpc",
-                    url="http://0.0.0.0:9999",
+                    url="http://example.com:9999",
                 )
             ]
         )
@@ -725,13 +726,79 @@ class TestCardBuilderBuildsContainers:
         builder = CardBuilder(session, card, handler)
         builder.with_factory(factory)
 
-        await builder.start()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGNTCY_A2A_HTTP_BIND_HOST", None)
+            await builder.start()
 
         session.add.assert_called_once()
-        mock_builder.with_host.assert_called_once_with("0.0.0.0")
+        # Advertised host comes from the card URL; bind host defaults to 0.0.0.0.
+        mock_builder.with_host.assert_called_once_with("example.com")
         mock_builder.with_port.assert_called_once_with(9999)
+        mock_builder.with_bind_host.assert_called_once_with("0.0.0.0")
         mock_builder.with_session_id.assert_called_once_with("http-0")
         session.start_all_sessions.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_http_bind_host_setter_precedence(self):
+        """`.with_http_bind_host()` takes precedence over env and default."""
+        mock_builder = MagicMock()
+        mock_builder.with_host.return_value = mock_builder
+        mock_builder.with_port.return_value = mock_builder
+        mock_builder.with_bind_host.return_value = mock_builder
+        mock_builder.with_session_id.return_value = mock_builder
+        mock_builder.build.return_value = MagicMock()
+
+        session = MagicMock()
+        session.add.return_value = mock_builder
+        session.start_all_sessions = AsyncMock()
+
+        card = _make_card(
+            interfaces=[
+                AgentInterface(transport="jsonrpc", url="http://example.com:9999")
+            ]
+        )
+        handler = MagicMock()
+        builder = CardBuilder(session, card, handler)
+        builder.with_factory(MagicMock())
+        builder.with_http_bind_host("127.0.0.1")
+
+        with patch.dict(
+            os.environ, {"AGNTCY_A2A_HTTP_BIND_HOST": "10.0.0.1"}, clear=False
+        ):
+            await builder.start()
+
+        mock_builder.with_host.assert_called_once_with("example.com")
+        mock_builder.with_bind_host.assert_called_once_with("127.0.0.1")
+
+    @pytest.mark.asyncio
+    async def test_http_bind_host_env(self):
+        """`AGNTCY_A2A_HTTP_BIND_HOST` is used when no setter is called."""
+        mock_builder = MagicMock()
+        mock_builder.with_host.return_value = mock_builder
+        mock_builder.with_port.return_value = mock_builder
+        mock_builder.with_bind_host.return_value = mock_builder
+        mock_builder.with_session_id.return_value = mock_builder
+        mock_builder.build.return_value = MagicMock()
+
+        session = MagicMock()
+        session.add.return_value = mock_builder
+        session.start_all_sessions = AsyncMock()
+
+        card = _make_card(
+            interfaces=[
+                AgentInterface(transport="jsonrpc", url="http://example.com:9999")
+            ]
+        )
+        handler = MagicMock()
+        builder = CardBuilder(session, card, handler)
+        builder.with_factory(MagicMock())
+
+        with patch.dict(
+            os.environ, {"AGNTCY_A2A_HTTP_BIND_HOST": "127.0.0.1"}, clear=False
+        ):
+            await builder.start()
+
+        mock_builder.with_bind_host.assert_called_once_with("127.0.0.1")
 
     @pytest.mark.asyncio
     async def test_builds_slim_container_topic_only(self):
@@ -1381,6 +1448,7 @@ class TestCardBuilderSkip:
         mock_builder = MagicMock()
         mock_builder.with_host.return_value = mock_builder
         mock_builder.with_port.return_value = mock_builder
+        mock_builder.with_bind_host.return_value = mock_builder
         mock_builder.with_session_id.return_value = mock_builder
         mock_builder.build.return_value = MagicMock()
 

--- a/tests/unit/test_jsonrpc_handler.py
+++ b/tests/unit/test_jsonrpc_handler.py
@@ -1,0 +1,92 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``A2AJsonRpcServerHandler`` bind-host decoupling."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agntcy_app_sdk.semantic.a2a.server.jsonrpc import A2AJsonRpcServerHandler
+
+
+def _make_server() -> MagicMock:
+    """Return a mock A2AStarletteApplication with a stub agent card."""
+    server = MagicMock()
+    server.agent_card = MagicMock()
+    return server
+
+
+class TestBindHost:
+    def test_defaults_bind_to_advertised_host(self):
+        handler = A2AJsonRpcServerHandler(_make_server(), host="example.com", port=9999)
+        assert handler._host == "example.com"
+        assert handler._bind_host == "example.com"
+        assert handler._port == 9999
+
+    def test_explicit_bind_host_overrides(self):
+        handler = A2AJsonRpcServerHandler(
+            _make_server(),
+            host="example.com",
+            port=9999,
+            bind_host="127.0.0.1",
+        )
+        # Advertised host unchanged; only the bind interface differs.
+        assert handler._host == "example.com"
+        assert handler._bind_host == "127.0.0.1"
+
+    def test_none_bind_host_falls_back_to_host(self):
+        handler = A2AJsonRpcServerHandler(
+            _make_server(),
+            host="0.0.0.0",
+            port=9999,
+            bind_host=None,
+        )
+        assert handler._bind_host == "0.0.0.0"
+
+    def test_agent_card_reports_advertised_host(self):
+        server = _make_server()
+        handler = A2AJsonRpcServerHandler(
+            server, host="example.com", port=9999, bind_host="0.0.0.0"
+        )
+        assert handler.agent_card is server.agent_card
+
+
+@pytest.mark.asyncio
+async def test_setup_binds_bind_host(monkeypatch):
+    """``setup()`` must configure uvicorn with the bind host, not the advertised host."""
+    captured = {}
+
+    class _FakeConfig:
+        def __init__(self, *, app, host, port, loop):
+            captured["host"] = host
+            captured["port"] = port
+
+    class _FakeServer:
+        def __init__(self, config):
+            self.should_exit = False
+
+        async def serve(self):
+            return None
+
+    monkeypatch.setattr(
+        "agntcy_app_sdk.semantic.a2a.server.jsonrpc.uvicorn.Config", _FakeConfig
+    )
+    monkeypatch.setattr(
+        "agntcy_app_sdk.semantic.a2a.server.jsonrpc.uvicorn.Server", _FakeServer
+    )
+
+    server = _make_server()
+    server.agent_card.preferred_transport = "JSONRPC"
+    server.build.return_value = MagicMock()
+
+    handler = A2AJsonRpcServerHandler(
+        server, host="example.com", port=9999, bind_host="0.0.0.0"
+    )
+    await handler.setup()
+    await handler.teardown()
+
+    assert captured["host"] == "0.0.0.0"
+    assert captured["port"] == 9999

--- a/tests/unit/test_jsonrpc_handler.py
+++ b/tests/unit/test_jsonrpc_handler.py
@@ -5,11 +5,39 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agntcy_app_sdk.semantic.a2a.server.jsonrpc import A2AJsonRpcServerHandler
+from agntcy_app_sdk.semantic.a2a.server.jsonrpc import (
+    A2AJsonRpcServerHandler,
+    resolve_http_bind_host,
+)
+
+
+class TestResolveHttpBindHost:
+    def test_default_all_interfaces(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGNTCY_A2A_HTTP_BIND_HOST", None)
+            assert resolve_http_bind_host() == "0.0.0.0"
+
+    def test_env_var(self):
+        with patch.dict(
+            os.environ, {"AGNTCY_A2A_HTTP_BIND_HOST": "127.0.0.1"}, clear=False
+        ):
+            assert resolve_http_bind_host() == "127.0.0.1"
+
+    def test_explicit_beats_env(self):
+        with patch.dict(
+            os.environ, {"AGNTCY_A2A_HTTP_BIND_HOST": "127.0.0.1"}, clear=False
+        ):
+            assert resolve_http_bind_host("10.0.0.1") == "10.0.0.1"
+
+    def test_explicit_beats_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGNTCY_A2A_HTTP_BIND_HOST", None)
+            assert resolve_http_bind_host("127.0.0.1") == "127.0.0.1"
 
 
 def _make_server() -> MagicMock:


### PR DESCRIPTION
# Description

This PR decouples the HTTP **bind host** from the **advertised** agent URL for A2A JSON-RPC/HTTP server flows.

Previously, when an agent card declared a `JSONRPC`/`HTTP` `AgentInterface`, the SDK bound the uvicorn server to the hostname taken from the card's advertised URL. This conflated two independent concerns (the address the server *listens on* and the address it *advertises to peers*), making it impossible to advertise a routable address while binding to all interfaces.

This change introduces a separate bind host that defaults to `0.0.0.0` and is independent of the advertised URL host. The advertised URL keeps serving only as the card's public address.

## Problem / Motivation

The advertised URL was forced to serve two roles at once, which breaks in any environment where the listen address and the reachable address differ, most notably Kubernetes:

- `url=http://my-service.my-namespace.svc.cluster.local:9999` → uvicorn tries to bind the Service ClusterIP (a virtual IP not present on any pod interface) → `Cannot assign requested address`, the server never starts.
- `url=http://0.0.0.0:9999` → binds fine but advertises `0.0.0.0`, which peers reading the directory record cannot dial.

## Root cause

`CardBuilder` passed the advertised URL's host straight into the builder's `.with_host(...)`, which became the uvicorn bind host. Bind host == advertised host, always.

## Solution

- `A2AJsonRpcServerHandler` gains a `bind_host` parameter. `host` remains the advertised/canonical host used for the card's `preferred_transport` stamp and logging; uvicorn binds `bind_host` (falling back to `host` for direct construction).
- `ContainerBuilder` gains `.with_bind_host(...)` and resolves the effective bind host in one place via a new pure helper `resolve_http_bind_host()` in `jsonrpc.py`.
- `CardBuilder` gains `.with_http_bind_host(...)` and only forwards an explicit override; default/env resolution lives downstream in `ContainerBuilder`, so both the direct-builder and card-driven paths behave identically.

## Configuration & precedence

The bind interface is resolved with the following precedence (advertised URL host is never used for binding):

1. Explicit setter: `ContainerBuilder.with_bind_host(...)` / `CardBuilder.with_http_bind_host(...)`
2. `AGNTCY_A2A_HTTP_BIND_HOST` environment variable
3. `0.0.0.0` (bind all interfaces), the default

Restore loopback-only binding with `AGNTCY_A2A_HTTP_BIND_HOST=127.0.0.1` or `.with_http_bind_host("127.0.0.1")`.

## Result for consumers

The Kubernetes case reduces to setting the card URL to a routable address (e.g. the Service DNS name) with the Service mapping to the container's target port. The server binds `0.0.0.0:<port>` and advertises the DNS name.

## Backward compatibility

- Functionally non-breaking for reachability: binding all interfaces is a superset of binding a specific one, so anything that reached `localhost:port` still reaches `0.0.0.0:port`.
- Behavioral note: the default bind changes from "advertised host" to `0.0.0.0`. Callers that intentionally want loopback-only binding must now opt in via the env var or setter. `parse_interface_url` validation and return shape are unchanged; the SLIM and NATS paths are untouched.

Scope included in this branch:

- Adds bind-host handling in app session and A2A JSON-RPC bootstrap/server paths.
- Updates card bootstrap behavior to align advertised URL vs bind address responsibilities.
- Documents the new behavior in A2A usage and API reference docs.
- Adds/extends unit tests for app session, card bootstrap, and JSON-RPC handler behavior.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [x] Refactor
- [x] Documentation
- [ ] Breaking Change
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass