### PR TITLE
fix: honor configured SLIM request timeout

### DIFF
--- a/src/agntcy_app_sdk/transport/slim/transport.py
+++ b/src/agntcy_app_sdk/transport/slim/transport.py
@@ -114,11 +114,25 @@ class SLIMTransport(BaseTransport):
         raise NotImplementedError
 
     async def request(
-        self, recipient: str, message: Message, timeout: int = 6, **kwargs
+        self,
+        recipient: str,
+        message: Message,
+        timeout: int | float | None = None,
+        **kwargs,
     ) -> Message:
         """
         Send a message to a recipient and await a single response.
+
+        Uses the transport's configured message timeout unless an explicit
+        per-request timeout is provided.
         """
+        effective_timeout = (
+            self.message_timeout
+            if timeout is None
+            else datetime.timedelta(seconds=timeout)
+        )
+        timeout_seconds = effective_timeout.total_seconds()
+
         topic = self.sanitize_topic(recipient)
         remote_name = self.build_name(topic)
 
@@ -132,7 +146,7 @@ class SLIMTransport(BaseTransport):
 
         # create a point-to-point session
         point_to_point_session = await self._session_manager.point_to_point_session(
-            remote_name, timeout=datetime.timedelta(seconds=timeout)
+            remote_name, timeout=effective_timeout
         )
 
         if not message.headers:
@@ -146,11 +160,11 @@ class SLIMTransport(BaseTransport):
             )
             # Wait for reply from remote peer
             reply = await point_to_point_session.get_message_async(
-                timeout=datetime.timedelta(seconds=timeout)
+                timeout=effective_timeout
             )
             logger.debug(f"Received message back from {remote_name}")
         except asyncio.TimeoutError:
-            logger.warning(f"Request timed out after {timeout} seconds")
+            logger.warning(f"Request timed out after {timeout_seconds:g} seconds")
             return None
         except Exception:
             logger.exception("Failed to publish message in p2p session")

--- a/tests/unit/test_slim_transport.py
+++ b/tests/unit/test_slim_transport.py
@@ -1,0 +1,91 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agntcy_app_sdk.semantic.message import Message
+from agntcy_app_sdk.transport.slim.transport import SLIMTransport
+
+pytest_plugins = "pytest_asyncio"
+
+
+def create_transport_with_mocks(
+    message_timeout: datetime.timedelta,
+) -> tuple[SLIMTransport, MagicMock, MagicMock]:
+    transport = SLIMTransport(
+        routable_name="test/client/requester",
+        endpoint="http://localhost:46357",
+        message_timeout=message_timeout,
+    )
+    transport._slim_app = AsyncMock()
+    transport._slim_connection_id = 7
+
+    response = Message(type="response", payload=b"ok")
+    session = MagicMock()
+    session.publish_async = AsyncMock()
+    session.get_message_async = AsyncMock(
+        return_value=SimpleNamespace(payload=response.serialize())
+    )
+    session.session_id.return_value = 123
+
+    session_manager = MagicMock()
+    session_manager.point_to_point_session = AsyncMock(return_value=session)
+    session_manager.close_session = AsyncMock()
+    transport._session_manager = session_manager
+
+    return transport, session, session_manager
+
+
+@pytest.mark.asyncio
+async def test_request_uses_configured_message_timeout() -> None:
+    configured_timeout = datetime.timedelta(seconds=45)
+    transport, session, session_manager = create_transport_with_mocks(
+        configured_timeout
+    )
+
+    response = await transport.request(
+        "test/server/responder",
+        Message(type="request", payload=b"hello"),
+    )
+
+    transport._slim_app.set_route_async.assert_awaited_once()
+    route_call = transport._slim_app.set_route_async.await_args
+    remote_name = route_call.args[0]
+
+    assert route_call.args[1] == 7
+    session_manager.point_to_point_session.assert_awaited_once_with(
+        remote_name,
+        timeout=configured_timeout,
+    )
+    session.get_message_async.assert_awaited_once_with(timeout=configured_timeout)
+    session_manager.close_session.assert_awaited_once_with(session)
+    assert response.payload == b"ok"
+
+
+@pytest.mark.asyncio
+async def test_request_timeout_overrides_configured_timeout() -> None:
+    transport, session, session_manager = create_transport_with_mocks(
+        datetime.timedelta(seconds=60)
+    )
+
+    response = await transport.request(
+        "test/server/responder",
+        Message(type="request", payload=b"hello"),
+        timeout=12.5,
+    )
+
+    route_call = transport._slim_app.set_route_async.await_args
+    remote_name = route_call.args[0]
+    overridden_timeout = datetime.timedelta(seconds=12.5)
+
+    session_manager.point_to_point_session.assert_awaited_once_with(
+        remote_name,
+        timeout=overridden_timeout,
+    )
+    session.get_message_async.assert_awaited_once_with(timeout=overridden_timeout)
+    session_manager.close_session.assert_awaited_once_with(session)
+    assert response.payload == b"ok"


### PR DESCRIPTION
# Description

Fixes the SLIM point-to-point request timeout so that `SLIMTransport.request()` uses the transport's configured `message_timeout` when no per-request timeout is supplied.

Previously, `request()` independently defaulted to 6 seconds even though `SLIMTransport` and `SlimTransportConfig` default to 60 seconds.

This change:

* Uses `self.message_timeout` as the default for point-to-point requests.
* Preserves explicit per-request timeout overrides.
* Supports fractional timeout values.
* Applies the same effective timeout to both session establishment and response waiting.
* Reports the effective timeout value in timeout warnings.
* Adds regression tests for configured-default and explicit-override behavior.

Fixes #120.

## Type of Change

* [x] Bugfix
* [ ] New Feature
* [ ] Breaking Change
* [ ] Refactor
* [ ] Documentation
* [ ] Other

## Testing

* `uv run --frozen pytest tests/unit/test_slim_transport.py -v`

  * 2 passed
* `uv run --frozen pytest tests/unit/ -q`

  * 243 passed
* `uv run --frozen ruff check`
* `uv run --frozen ruff format --check`
* `git diff --check`

## Checklist

* [x] I have read the [contributing guidelines](/agntcy/app-sdk/blob/main/CONTRIBUTING.md)
* [x] Existing issues have been referenced where applicable
* [x] I have verified this change is not present in other open pull requests
* [x] Functionality is documented
* [x] All code style checks pass
* [x] New code contribution is covered by automated tests
* [x] All new and existing tests pass
